### PR TITLE
Add prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": false,
+  "arrowParens": "always",
+  "trailingComma": "all"
+}

--- a/cli/src/plugins/dependencyPlugin.js
+++ b/cli/src/plugins/dependencyPlugin.js
@@ -162,7 +162,7 @@ export function dependencyPlugin() {
 
 			// Serialize import map and fix indentation so it looks nice when debugging
 			const importMapString = JSON.stringify(importMap, null, 2)
-				.replace(/  /g, "\t")
+				.replace(/ {2}/g, "\t")
 				.replace(/\n/g, "\n\t\t");
 
 			return {


### PR DESCRIPTION
Specify this repositories style so when it is included in other repos the current style is maintained.

When submoduled into a repo like Preact core, Prettier in VSCode inherits the parents style. Adding this so that the current style is maintained.

Alternatively, I could update this repo's style to match Preact core. Do people have a preference?